### PR TITLE
Add setting to replace alt with control

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -40,6 +40,12 @@
 			"default": 45
 		},
 
+		"ctrl": {
+			"name": "Use control instead of alt",
+			"description": "Use the control key to spawn the alternate text box instead of the alt key",
+			"type": "bool",
+			"default": false
+		},
 
 		"missingIDWarn": {
             "name": "Warn when missing ID",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -95,7 +95,14 @@ bool dontShowPopupHere() {
 }
 
 bool getShift() { return CCKeyboardDispatcher::get()->getShiftKeyPressed(); }
-bool getAlt() { return CCKeyboardDispatcher::get()->getAltKeyPressed(); }
+bool getAlt() { 
+	if (Mod::get()->getSettingValue<bool>("ctrl")) {
+		return CCKeyboardDispatcher::get()->getControlKeyPressed();
+	}
+	else {
+		return CCKeyboardDispatcher::get()->getAltKeyPressed();
+	}
+}
 
 void prepPopup() {
 	if (dontShowPopupHere()) return;


### PR DESCRIPTION
I have not tested this on mac, but I made it because I really want a textbox that only spawns when I press control+G. 